### PR TITLE
chore: add charm description to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,12 @@
-<!--
-Avoid using this README file for information that is maintained or published elsewhere, e.g.:
-
-* metadata.yaml > published on Charmhub
-* documentation > published on (or linked to from) Charmhub
-* detailed contribution guide > documentation or CONTRIBUTING.md
-
-Use links instead.
--->
-
 # lego-operator
 
-Charmhub package name: operator-template
+Charmhub package name: lego
 More information: https://charmhub.io/lego-operator
 
-Describe your charm in one or two sentences.
+A charm that provides TLS Certificates from a Let's Encrypt server and distributes them via the tls-certificates interface.
 
 ## Other resources
 
-<!-- If your charm is documented somewhere else other than Charmhub, provide a link separately. -->
-
-- [Read more](https://example.com)
-
-- [Contributing](CONTRIBUTING.md) <!-- or link to other contribution documentation -->
+- [Contributing](CONTRIBUTING.md)
 
 - See the [Juju SDK documentation](https://juju.is/docs/sdk) for more information about developing and improving charms.


### PR DESCRIPTION
# Description

The readme contained template content. Here we replace it with actual information on the `lego` charm.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
