### PR TITLE
feat: Add warning log when receiving `ModelError`

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -180,7 +180,7 @@ class LegoCharm(CharmBase):
         if not self._server:
             return "acme server was not provided"
         if not self._plugin_config:
-            return "plugin configuration secret was not provided"
+            return "plugin configuration secret is not available"
         if not self._plugin:
             return "plugin was not provided"
         if not _email_is_valid(self._email):
@@ -255,7 +255,10 @@ class LegoCharm(CharmBase):
                 return {}
             plugin_config_secret: Secret = self.model.get_secret(id=plugin_config_secret_id)
             plugin_config = plugin_config_secret.get_content(refresh=True)
-        except (SecretNotFoundError, ModelError):
+        except SecretNotFoundError:
+            return {}
+        except ModelError as e:
+            logger.warning("unable to access the secret: %s", e)
             return {}
         return {key.upper().replace("-", "_"): value for key, value in plugin_config.items()}
 

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -63,7 +63,7 @@ class TestLegoOperatorCharmCollectStatus:
             },
         )
         out = self.ctx.run(self.ctx.on.collect_unit_status(), state)
-        assert out.unit_status == BlockedStatus("plugin configuration secret was not provided")
+        assert out.unit_status == BlockedStatus("plugin configuration secret is not available")
 
     def test_given_plugin_not_provided_when_update_config_then_status_is_blocked(self):
         state = State(


### PR DESCRIPTION
I've been unable to reproduce or deduce what might be causing #17 .

This adds a warning log when a `ModelError` is received, I'm hoping it will give us a little more details on what is going wrong.

I also changed the wording of the error message a bit, as it was a little misleading.

We could also be less vague and provide different messages for the different scenarios (not provided, inaccessible, etc). This would require a small refactor, though, so I left it out for now.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
