### PR TITLE
chore: Add devenv dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,12 @@ pass_env =
     CHARM_BUILD_DIR
     MODEL_SETTINGS
 
+[testenv:py]
+# These are the base dependencies used when `tox devenv` is run
+deps =
+    -r {tox_root}/requirements.txt
+    -r {toxinidir}/test-requirements.txt
+
 [testenv:format]
 description = Apply coding style standards to code
 deps =


### PR DESCRIPTION
This installs the requirements and test-requirements when `tox devenv` is run.

I'm admittedly not familiar with the `py` env, but it doesn't seem to be run by default (when `tox` is run without args) and it only seems to install the deps when `tox devenv` is run, so it seemed to work.

I got the idea from the default value for `-e` described here: https://tox.wiki/en/4.23.2/cli_interface.html#tox-devenv-(d)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
