### PR TITLE
build: Enable pyright to check if type hints are missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,4 @@ skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
 include = ["src/**.py"]
+reportMissingParameterType = true

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,7 @@ import logging
 import os
 import re
 from contextlib import contextmanager
-from typing import Dict
+from typing import Any, Dict
 from urllib.parse import urlparse
 
 from charms.certificate_transfer_interface.v1.certificate_transfer import (
@@ -41,7 +41,7 @@ class LegoCharm(CharmBase):
     This charm implements the tls_certificates interface as a provider.
     """
 
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         super().__init__(*args)
         self._logging = LogForwarder(self, relation_name="logging")
         self.tls_certificates = TLSCertificatesProvidesV4(self, CERTIFICATES_RELATION_NAME)

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -4,7 +4,7 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from charms.tls_certificates_interface.v4.tls_certificates import (
     ProviderCertificate,
@@ -156,7 +156,10 @@ class TestLegoOperatorCharmCollectStatus:
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.get_provider_certificates")
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.get_certificate_requests")
     def test_given_valid_config_and_pending_requests_when_update_status_then_status_is_active(
-        self, mock_get_certificate_requests, mock_get_provider_certificates, mock_pylego
+        self,
+        mock_get_certificate_requests: MagicMock,
+        mock_get_provider_certificates: MagicMock,
+        mock_pylego: MagicMock,
     ):
         csr_pk_1 = generate_private_key()
         csr_1 = generate_csr(csr_pk_1, "foo.com")

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -4,7 +4,7 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from charms.tls_certificates_interface.v4.tls_certificates import (
     ProviderCertificate,
@@ -37,7 +37,10 @@ class TestLegoOperatorCharmConfigure:
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.get_certificate_requests")
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.set_relation_certificate")
     def test_given_cmd_when_certificate_creation_request_then_certificate_is_set_in_relation(
-        self, mock_set_relation_certificate, mock_get_outstanding_certificate_requests, mock_pylego
+        self,
+        mock_set_relation_certificate: MagicMock,
+        mock_get_outstanding_certificate_requests: MagicMock,
+        mock_pylego: MagicMock,
     ):
         csr_pk = generate_private_key()
         csr = generate_csr(csr_pk, "foo.com")
@@ -97,7 +100,10 @@ class TestLegoOperatorCharmConfigure:
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.get_certificate_requests")
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.set_relation_certificate")
     def test_given_cmd_execution_fails_when_certificate_creation_request_then_request_fails(
-        self, mock_set_relation_certificate, mock_get_certificate_requests, mock_pylego
+        self,
+        mock_set_relation_certificate: MagicMock,
+        mock_get_certificate_requests: MagicMock,
+        mock_pylego: MagicMock,
     ):
         csr_pk = generate_private_key()
         csr = generate_csr(csr_pk, "foo.com")
@@ -148,8 +154,8 @@ class TestLegoOperatorCharmConfigure:
     @patch("charm.run_lego_command")
     def test_given_cmd_when_app_environment_variables_set_then_command_executed_with_environment_variables(  # noqa: E501
         self,
-        mock_pylego,
-        mock_get_certificate_requests,
+        mock_pylego: MagicMock,
+        mock_get_certificate_requests: MagicMock,
     ):
         csr_pk = generate_private_key()
         csr = generate_csr(csr_pk, "foo.com")
@@ -202,7 +208,7 @@ class TestLegoOperatorCharmConfigure:
 
     @patch(f"{CERT_TRANSFER_LIB_PATH}.CertificateTransferProvides.add_certificates")
     def test_given_cert_transfer_relation_not_created_then_ca_certificates_not_added_in_relation_data(  # noqa: E501
-        self, mock_add_certificates
+        self, mock_add_certificates: MagicMock
     ):
         state = State(
             leader=True,
@@ -225,7 +231,7 @@ class TestLegoOperatorCharmConfigure:
     @patch(f"{CERT_TRANSFER_LIB_PATH}.CertificateTransferProvides.add_certificates")
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.get_provider_certificates")
     def test_given_cert_transfer_relation_and_ca_certificates_then_ca_certificates_added_in_relation_data(  # noqa: E501
-        self, mock_get_provider_certificates, mock_add_certificates
+        self, mock_get_provider_certificates: MagicMock, mock_add_certificates: MagicMock
     ):
         private_key = generate_private_key()
         csr = generate_csr(private_key, "foo.com")


### PR DESCRIPTION
This change adds a pyright check to ensure that we add type hints to our code
