### PR TITLE
fix: Get the first certificate only from the Certificate Bundle

### DIFF
--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -56,7 +56,7 @@ class TestLegoOperatorCharmConfigure:
         mock_pylego.return_value = LEGOResponse(
             csr=str(csr),
             private_key=str(generate_private_key()),
-            certificate=str(cert),
+            certificate=f"{str(cert)}\n{str(issuer)}",
             issuer_certificate=str(issuer),
             metadata=Metadata(stable_url="stable url", url="url", domain="domain.com"),
         )
@@ -170,7 +170,7 @@ class TestLegoOperatorCharmConfigure:
         mock_pylego.return_value = LEGOResponse(
             csr=str(csr),
             private_key=str(generate_private_key()),
-            certificate=str(cert),
+            certificate=f"{str(cert)}\n{str(issuer)}",
             issuer_certificate=str(issuer),
             metadata=Metadata(stable_url="stable url", url="url", domain="domain.com"),
         )


### PR DESCRIPTION
# Description

Currently Lego returns the chain in the Certificate field of its response, this PR gets the first one which should be the end certificate to put it to relation data.

This PR doesn't assume that the behaviour of Pylego will remain the same at all times of returning a bundle of certs int the certificate field, this should work completely fine event if there is only one certificate in the certificate field.

Fixes #23 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
