### PR TITLE
build: Select 24.04 version for testing

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         arch:
           - arch: amd64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
   
     runs-on: ${{ matrix.arch.runner }}
     steps:
@@ -24,7 +24,7 @@ jobs:
       
       - name: Get Charm Under Test Path
         id: charm-path
-        run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+        run: echo "charm_path=$(find built/ -name '*@24.04-amd64.charm' -type f -print)" >> $GITHUB_OUTPUT
       
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main


### PR DESCRIPTION
[A recent change to the charmcraft.yaml](https://github.com/canonical/lego-operator/pull/82) builds multiple versions of the charm. It [breaks the build](https://github.com/canonical/lego-operator/actions/runs/17630105020/job/50224364857?pr=89), as it doesn't know which charm to select for testing.

This change selects the 24.04 version for testing.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
